### PR TITLE
Backport twig function `absolute_url` from Symfony 4.3

### DIFF
--- a/bamboo_twig_file/bamboo_twig_file.services.yml
+++ b/bamboo_twig_file/bamboo_twig_file.services.yml
@@ -1,6 +1,14 @@
 services:
+    bamboo_twig_file.url_helper:
+        class: Drupal\bamboo_twig_file\UrlHelper
+        arguments:
+          - '@request_stack'
+          - '@router.request_context'
+
     bamboo_twig_file.twig.file:
         class: Drupal\bamboo_twig_file\TwigExtension\File
         tags:
             - { name: twig.extension }
+        arguments:
+          - '@bamboo_twig_file.url_helper'
         parent: bamboo_twig.twig.base

--- a/bamboo_twig_file/src/TwigExtension/File.php
+++ b/bamboo_twig_file/src/TwigExtension/File.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\bamboo_twig_file\TwigExtension;
 
+use Drupal\bamboo_twig_file\UrlHelper;
 use Twig\TwigFunction;
 use Twig\TwigFilter;
 use Drupal\bamboo_twig\TwigExtension\TwigExtensionBase;
@@ -10,6 +11,21 @@ use Drupal\bamboo_twig\TwigExtension\TwigExtensionBase;
  * Provides a 'File' Twig Extensions.
  */
 class File extends TwigExtensionBase {
+
+  /**
+   * @var \Drupal\bamboo_twig_file\UrlHelper
+   */
+  private $urlHelper;
+
+  /**
+   * File Twig Extension constructor.
+   *
+   * @param \Drupal\bamboo_twig_file\UrlHelper $urlHelper
+   *   Helper to build absolute url.
+   */
+  public function __construct(UrlHelper $urlHelper) {
+    $this->urlHelper = $urlHelper;
+  }
 
   /**
    * List of all Twig functions.
@@ -30,6 +46,14 @@ class File extends TwigExtensionBase {
       new TwigFunction('bamboo_file_url_absolute', [
         $this, 'urlAbsolute',
       ]),
+      new TwigFunction('bamboo_absolute_url', [
+        $this->urlHelper,
+        'getAbsoluteUrl'
+      ]),
+      new TwigFunction('bamboo_relative_url', [
+        $this->urlHelper,
+        'getRelativePath'
+      ])
     ];
   }
 

--- a/bamboo_twig_file/src/TwigExtension/File.php
+++ b/bamboo_twig_file/src/TwigExtension/File.php
@@ -50,7 +50,7 @@ class File extends TwigExtensionBase {
         $this->urlHelper,
         'getAbsoluteUrl'
       ]),
-      new TwigFunction('bamboo_relative_url', [
+      new TwigFunction('bamboo_relative_path', [
         $this->urlHelper,
         'getRelativePath'
       ])

--- a/bamboo_twig_file/src/TwigExtension/File.php
+++ b/bamboo_twig_file/src/TwigExtension/File.php
@@ -13,6 +13,8 @@ use Drupal\bamboo_twig\TwigExtension\TwigExtensionBase;
 class File extends TwigExtensionBase {
 
   /**
+   * URL Helper.
+   *
    * @var \Drupal\bamboo_twig_file\UrlHelper
    */
   private $urlHelper;
@@ -48,12 +50,12 @@ class File extends TwigExtensionBase {
       ]),
       new TwigFunction('bamboo_absolute_url', [
         $this->urlHelper,
-        'getAbsoluteUrl'
+        'getAbsoluteUrl',
       ]),
       new TwigFunction('bamboo_relative_path', [
         $this->urlHelper,
-        'getRelativePath'
-      ])
+        'getRelativePath',
+      ]),
     ];
   }
 

--- a/bamboo_twig_file/src/UrlHelper.php
+++ b/bamboo_twig_file/src/UrlHelper.php
@@ -1,0 +1,106 @@
+<?php
+
+/*
+ * This file is backported from Symfony 4.3+
+ * https://github.com/symfony/symfony/blob/5.x/src/Symfony/Component/HttpFoundation/UrlHelper.php
+ *
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Drupal\bamboo_twig_file;
+
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Routing\RequestContext;
+
+/**
+ * A helper service for manipulating URLs within and outside the request scope.
+ *
+ * @author Valentin Udaltsov <udaltsov.valentin@gmail.com>
+ */
+final class UrlHelper
+{
+    private $requestStack;
+    private $requestContext;
+
+    public function __construct(RequestStack $requestStack, RequestContext $requestContext = null)
+    {
+        $this->requestStack = $requestStack;
+        $this->requestContext = $requestContext;
+    }
+
+    public function getAbsoluteUrl(string $path): string
+    {
+        if (false !== strpos($path, '://') || '//' === substr($path, 0, 2)) {
+            return $path;
+        }
+
+        if (null === $request = $this->requestStack->getMasterRequest()) {
+            return $this->getAbsoluteUrlFromContext($path);
+        }
+
+        if ('#' === $path[0]) {
+            $path = $request->getRequestUri().$path;
+        } elseif ('?' === $path[0]) {
+            $path = $request->getPathInfo().$path;
+        }
+
+        if (!$path || '/' !== $path[0]) {
+            $prefix = $request->getPathInfo();
+            $last = \strlen($prefix) - 1;
+            if ($last !== $pos = strrpos($prefix, '/')) {
+                $prefix = substr($prefix, 0, $pos).'/';
+            }
+
+            return $request->getUriForPath($prefix.$path);
+        }
+
+        return $request->getSchemeAndHttpHost().$path;
+    }
+
+    public function getRelativePath(string $path): string
+    {
+        if (false !== strpos($path, '://') || '//' === substr($path, 0, 2)) {
+            return $path;
+        }
+
+        if (null === $request = $this->requestStack->getMasterRequest()) {
+            return $path;
+        }
+
+        return $request->getRelativeUriForPath($path);
+    }
+
+    private function getAbsoluteUrlFromContext(string $path): string
+    {
+        if (null === $this->requestContext || '' === $host = $this->requestContext->getHost()) {
+            return $path;
+        }
+
+        $scheme = $this->requestContext->getScheme();
+        $port = '';
+
+        if ('http' === $scheme && 80 !== $this->requestContext->getHttpPort()) {
+            $port = ':'.$this->requestContext->getHttpPort();
+        } elseif ('https' === $scheme && 443 !== $this->requestContext->getHttpsPort()) {
+            $port = ':'.$this->requestContext->getHttpsPort();
+        }
+
+        if ('#' === $path[0]) {
+            $queryString = $this->requestContext->getQueryString();
+            $path = $this->requestContext->getPathInfo().($queryString ? '?'.$queryString : '').$path;
+        } elseif ('?' === $path[0]) {
+            $path = $this->requestContext->getPathInfo().$path;
+        }
+
+        if ('/' !== $path[0]) {
+            $path = rtrim($this->requestContext->getBaseUrl(), '/').'/'.$path;
+        }
+
+        return $scheme.'://'.$host.$port.$path;
+    }
+}

--- a/bamboo_twig_file/src/UrlHelper.php
+++ b/bamboo_twig_file/src/UrlHelper.php
@@ -1,17 +1,5 @@
 <?php
 
-/*
- * This file is backported from Symfony 4.3+
- * https://github.com/symfony/symfony/blob/5.x/src/Symfony/Component/HttpFoundation/UrlHelper.php
- *
- * This file is part of the Symfony package.
- *
- * (c) Fabien Potencier <fabien@symfony.com>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Drupal\bamboo_twig_file;
 
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -20,87 +8,123 @@ use Symfony\Component\Routing\RequestContext;
 /**
  * A helper service for manipulating URLs within and outside the request scope.
  *
- * @author Valentin Udaltsov <udaltsov.valentin@gmail.com>
+ * This file is backported from Symfony 4.3+
+ * https://github.com/symfony/symfony/blob/5.x/src/Symfony/Component/HttpFoundation/UrlHelper.php.
+ *
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
  */
-final class UrlHelper
-{
-    private $requestStack;
-    private $requestContext;
+final class UrlHelper {
 
-    public function __construct(RequestStack $requestStack, RequestContext $requestContext = null)
-    {
-        $this->requestStack = $requestStack;
-        $this->requestContext = $requestContext;
+  /**
+   * The Symfony Request Stack.
+   *
+   * @var \Symfony\Component\HttpFoundation\RequestStack
+   */
+  private $requestStack;
+
+  /**
+   * The Request Context.
+   *
+   * @var \Symfony\Component\Routing\RequestContext|null
+   */
+  private $requestContext;
+
+  /**
+   * Constructor.
+   *
+   * @param \Symfony\Component\HttpFoundation\RequestStack $requestStack
+   *   The Symfony Request Stack.
+   * @param \Symfony\Component\Routing\RequestContext|null $requestContext
+   *   The Request Context.
+   */
+  public function __construct(RequestStack $requestStack, RequestContext $requestContext = NULL) {
+    $this->requestStack = $requestStack;
+    $this->requestContext = $requestContext;
+  }
+
+  /**
+   * Transform a relative path to an absolute URL.
+   */
+  public function getAbsoluteUrl(string $path): string {
+    if (FALSE !== strpos($path, '://') || '//' === substr($path, 0, 2)) {
+      return $path;
     }
 
-    public function getAbsoluteUrl(string $path): string
-    {
-        if (false !== strpos($path, '://') || '//' === substr($path, 0, 2)) {
-            return $path;
-        }
-
-        if (null === $request = $this->requestStack->getMasterRequest()) {
-            return $this->getAbsoluteUrlFromContext($path);
-        }
-
-        if ('#' === $path[0]) {
-            $path = $request->getRequestUri().$path;
-        } elseif ('?' === $path[0]) {
-            $path = $request->getPathInfo().$path;
-        }
-
-        if (!$path || '/' !== $path[0]) {
-            $prefix = $request->getPathInfo();
-            $last = \strlen($prefix) - 1;
-            if ($last !== $pos = strrpos($prefix, '/')) {
-                $prefix = substr($prefix, 0, $pos).'/';
-            }
-
-            return $request->getUriForPath($prefix.$path);
-        }
-
-        return $request->getSchemeAndHttpHost().$path;
+    if (NULL === $request = $this->requestStack->getMasterRequest()) {
+      return $this->getAbsoluteUrlFromContext($path);
     }
 
-    public function getRelativePath(string $path): string
-    {
-        if (false !== strpos($path, '://') || '//' === substr($path, 0, 2)) {
-            return $path;
-        }
-
-        if (null === $request = $this->requestStack->getMasterRequest()) {
-            return $path;
-        }
-
-        return $request->getRelativeUriForPath($path);
+    if ('#' === $path[0]) {
+      $path = $request->getRequestUri() . $path;
+    }
+    elseif ('?' === $path[0]) {
+      $path = $request->getPathInfo() . $path;
     }
 
-    private function getAbsoluteUrlFromContext(string $path): string
-    {
-        if (null === $this->requestContext || '' === $host = $this->requestContext->getHost()) {
-            return $path;
-        }
+    if (!$path || '/' !== $path[0]) {
+      $prefix = $request->getPathInfo();
+      $last = \strlen($prefix) - 1;
+      if ($last !== $pos = strrpos($prefix, '/')) {
+        $prefix = substr($prefix, 0, $pos) . '/';
+      }
 
-        $scheme = $this->requestContext->getScheme();
-        $port = '';
-
-        if ('http' === $scheme && 80 !== $this->requestContext->getHttpPort()) {
-            $port = ':'.$this->requestContext->getHttpPort();
-        } elseif ('https' === $scheme && 443 !== $this->requestContext->getHttpsPort()) {
-            $port = ':'.$this->requestContext->getHttpsPort();
-        }
-
-        if ('#' === $path[0]) {
-            $queryString = $this->requestContext->getQueryString();
-            $path = $this->requestContext->getPathInfo().($queryString ? '?'.$queryString : '').$path;
-        } elseif ('?' === $path[0]) {
-            $path = $this->requestContext->getPathInfo().$path;
-        }
-
-        if ('/' !== $path[0]) {
-            $path = rtrim($this->requestContext->getBaseUrl(), '/').'/'.$path;
-        }
-
-        return $scheme.'://'.$host.$port.$path;
+      return $request->getUriForPath($prefix . $path);
     }
+
+    return $request->getSchemeAndHttpHost() . $path;
+  }
+
+  /**
+   * Transform an absolute url to a relative path.
+   */
+  public function getRelativePath(string $path): string {
+    if (FALSE !== strpos($path, '://') || '//' === substr($path, 0, 2)) {
+      return $path;
+    }
+
+    if (NULL === $request = $this->requestStack->getMasterRequest()) {
+      return $path;
+    }
+
+    return $request->getRelativeUriForPath($path);
+  }
+
+  /**
+   * Internal method to get the absolute url from the context.
+   */
+  private function getAbsoluteUrlFromContext(string $path): string {
+    if (NULL === $this->requestContext || '' === $host = $this->requestContext->getHost()) {
+      return $path;
+    }
+
+    $scheme = $this->requestContext->getScheme();
+    $port = '';
+
+    if ('http' === $scheme && 80 !== $this->requestContext->getHttpPort()) {
+      $port = ':' . $this->requestContext->getHttpPort();
+    }
+    elseif ('https' === $scheme && 443 !== $this->requestContext->getHttpsPort()) {
+      $port = ':' . $this->requestContext->getHttpsPort();
+    }
+
+    if ('#' === $path[0]) {
+      $queryString = $this->requestContext->getQueryString();
+      $path = $this->requestContext->getPathInfo() . ($queryString ? '?' . $queryString : '') . $path;
+    }
+    elseif ('?' === $path[0]) {
+      $path = $this->requestContext->getPathInfo() . $path;
+    }
+
+    if ('/' !== $path[0]) {
+      $path = rtrim($this->requestContext->getBaseUrl(), '/') . '/' . $path;
+    }
+
+    return $scheme . '://' . $host . $port . $path;
+  }
+
 }

--- a/tests/src/Kernel/UrlHelperTest.php
+++ b/tests/src/Kernel/UrlHelperTest.php
@@ -1,0 +1,143 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Drupal\Tests\bamboo_twig\Kernel;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Drupal\bamboo_twig_file\UrlHelper;
+use Symfony\Component\Routing\RequestContext;
+
+class UrlHelperTest extends TestCase
+{
+  /**
+   * @dataProvider getGenerateAbsoluteUrlData()
+   */
+  public function testGenerateAbsoluteUrl($expected, $path, $pathinfo)
+  {
+    $stack = new RequestStack();
+    $stack->push(Request::create($pathinfo));
+    $helper = new UrlHelper($stack);
+
+    $this->assertEquals($expected, $helper->getAbsoluteUrl($path));
+  }
+
+  public function getGenerateAbsoluteUrlData()
+  {
+    return [
+      ['http://localhost/foo.png', '/foo.png', '/foo/bar.html'],
+      ['http://localhost/foo/foo.png', 'foo.png', '/foo/bar.html'],
+      ['http://localhost/foo/foo.png', 'foo.png', '/foo/bar'],
+      ['http://localhost/foo/bar/foo.png', 'foo.png', '/foo/bar/'],
+
+      ['http://example.com/baz', 'http://example.com/baz', '/'],
+      ['https://example.com/baz', 'https://example.com/baz', '/'],
+      ['//example.com/baz', '//example.com/baz', '/'],
+
+      ['http://localhost/foo/bar?baz', '?baz', '/foo/bar'],
+      ['http://localhost/foo/bar?baz=1', '?baz=1', '/foo/bar?foo=1'],
+      ['http://localhost/foo/baz?baz=1', 'baz?baz=1', '/foo/bar?foo=1'],
+
+      ['http://localhost/foo/bar#baz', '#baz', '/foo/bar'],
+      ['http://localhost/foo/bar?0#baz', '#baz', '/foo/bar?0'],
+      ['http://localhost/foo/bar?baz=1#baz', '?baz=1#baz', '/foo/bar?foo=1'],
+      ['http://localhost/foo/baz?baz=1#baz', 'baz?baz=1#baz', '/foo/bar?foo=1'],
+    ];
+  }
+
+  /**
+   * @dataProvider getGenerateAbsoluteUrlRequestContextData
+   */
+  public function testGenerateAbsoluteUrlWithRequestContext($path, $baseUrl, $host, $scheme, $httpPort, $httpsPort, $expected)
+  {
+    if (!class_exists('Symfony\Component\Routing\RequestContext')) {
+      $this->markTestSkipped('The Routing component is needed to run tests that depend on its request context.');
+    }
+
+    $requestContext = new RequestContext($baseUrl, 'GET', $host, $scheme, $httpPort, $httpsPort, $path);
+    $helper = new UrlHelper(new RequestStack(), $requestContext);
+
+    $this->assertEquals($expected, $helper->getAbsoluteUrl($path));
+  }
+
+  /**
+   * @dataProvider getGenerateAbsoluteUrlRequestContextData
+   */
+  public function testGenerateAbsoluteUrlWithoutRequestAndRequestContext($path)
+  {
+    if (!class_exists('Symfony\Component\Routing\RequestContext')) {
+      $this->markTestSkipped('The Routing component is needed to run tests that depend on its request context.');
+    }
+
+    $helper = new UrlHelper(new RequestStack());
+
+    $this->assertEquals($path, $helper->getAbsoluteUrl($path));
+  }
+
+  public function getGenerateAbsoluteUrlRequestContextData()
+  {
+    return [
+      ['/foo.png', '/foo', 'localhost', 'http', 80, 443, 'http://localhost/foo.png'],
+      ['foo.png', '/foo', 'localhost', 'http', 80, 443, 'http://localhost/foo/foo.png'],
+      ['foo.png', '/foo/bar/', 'localhost', 'http', 80, 443, 'http://localhost/foo/bar/foo.png'],
+      ['/foo.png', '/foo', 'localhost', 'https', 80, 443, 'https://localhost/foo.png'],
+      ['foo.png', '/foo', 'localhost', 'https', 80, 443, 'https://localhost/foo/foo.png'],
+      ['foo.png', '/foo/bar/', 'localhost', 'https', 80, 443, 'https://localhost/foo/bar/foo.png'],
+      ['/foo.png', '/foo', 'localhost', 'http', 443, 80, 'http://localhost:443/foo.png'],
+      ['/foo.png', '/foo', 'localhost', 'https', 443, 80, 'https://localhost:80/foo.png'],
+    ];
+  }
+
+  public function testGenerateAbsoluteUrlWithScriptFileName()
+  {
+    $request = Request::create('http://localhost/app/web/app_dev.php');
+    $request->server->set('SCRIPT_FILENAME', '/var/www/app/web/app_dev.php');
+
+    $stack = new RequestStack();
+    $stack->push($request);
+    $helper = new UrlHelper($stack);
+
+    $this->assertEquals(
+      'http://localhost/app/web/bundles/framework/css/structure.css',
+      $helper->getAbsoluteUrl('/app/web/bundles/framework/css/structure.css')
+    );
+  }
+
+  /**
+   * @dataProvider getGenerateRelativePathData()
+   */
+  public function testGenerateRelativePath($expected, $path, $pathinfo)
+  {
+    if (!method_exists('Symfony\Component\HttpFoundation\Request', 'getRelativeUriForPath')) {
+      $this->markTestSkipped('Your version of Symfony HttpFoundation is too old.');
+    }
+
+    $stack = new RequestStack();
+    $stack->push(Request::create($pathinfo));
+    $urlHelper = new UrlHelper($stack);
+
+    $this->assertEquals($expected, $urlHelper->getRelativePath($path));
+  }
+
+  public function getGenerateRelativePathData()
+  {
+    return [
+      ['../foo.png', '/foo.png', '/foo/bar.html'],
+      ['../baz/foo.png', '/baz/foo.png', '/foo/bar.html'],
+      ['baz/foo.png', 'baz/foo.png', '/foo/bar.html'],
+
+      ['http://example.com/baz', 'http://example.com/baz', '/'],
+      ['https://example.com/baz', 'https://example.com/baz', '/'],
+      ['//example.com/baz', '//example.com/baz', '/'],
+    ];
+  }
+}

--- a/tests/src/Unit/UrlHelperTest.php
+++ b/tests/src/Unit/UrlHelperTest.php
@@ -1,15 +1,6 @@
 <?php
 
-/*
- * This file is part of the Symfony package.
- *
- * (c) Fabien Potencier <fabien@symfony.com>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
-namespace Drupal\Tests\bamboo_twig\Kernel;
+namespace Drupal\Tests\bamboo_twig\Unit;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
@@ -17,13 +8,17 @@ use Symfony\Component\HttpFoundation\RequestStack;
 use Drupal\bamboo_twig_file\UrlHelper;
 use Symfony\Component\Routing\RequestContext;
 
-class UrlHelperTest extends TestCase
-{
+/**
+ * Test of the UrlHelper class.
+ */
+class UrlHelperTest extends TestCase {
+
   /**
+   * TestGenerateAbsoluteUrl.
+   *
    * @dataProvider getGenerateAbsoluteUrlData()
    */
-  public function testGenerateAbsoluteUrl($expected, $path, $pathinfo)
-  {
+  public function testGenerateAbsoluteUrl($expected, $path, $pathinfo) {
     $stack = new RequestStack();
     $stack->push(Request::create($pathinfo));
     $helper = new UrlHelper($stack);
@@ -31,8 +26,11 @@ class UrlHelperTest extends TestCase
     $this->assertEquals($expected, $helper->getAbsoluteUrl($path));
   }
 
-  public function getGenerateAbsoluteUrlData()
-  {
+  /**
+   * GetGenerateAbsoluteUrlData.
+   */
+  public function getGenerateAbsoluteUrlData() {
+    // phpcs:disable Drupal.Arrays.Array.LongLineDeclaration
     return [
       ['http://localhost/foo.png', '/foo.png', '/foo/bar.html'],
       ['http://localhost/foo/foo.png', 'foo.png', '/foo/bar.html'],
@@ -55,10 +53,11 @@ class UrlHelperTest extends TestCase
   }
 
   /**
+   * TestGenerateAbsoluteUrlWithRequestContext.
+   *
    * @dataProvider getGenerateAbsoluteUrlRequestContextData
    */
-  public function testGenerateAbsoluteUrlWithRequestContext($path, $baseUrl, $host, $scheme, $httpPort, $httpsPort, $expected)
-  {
+  public function testGenerateAbsoluteUrlWithRequestContext($path, $baseUrl, $host, $scheme, $httpPort, $httpsPort, $expected) {
     if (!class_exists('Symfony\Component\Routing\RequestContext')) {
       $this->markTestSkipped('The Routing component is needed to run tests that depend on its request context.');
     }
@@ -70,10 +69,11 @@ class UrlHelperTest extends TestCase
   }
 
   /**
+   * TestGenerateAbsoluteUrlWithoutRequestAndRequestContext.
+   *
    * @dataProvider getGenerateAbsoluteUrlRequestContextData
    */
-  public function testGenerateAbsoluteUrlWithoutRequestAndRequestContext($path)
-  {
+  public function testGenerateAbsoluteUrlWithoutRequestAndRequestContext($path) {
     if (!class_exists('Symfony\Component\Routing\RequestContext')) {
       $this->markTestSkipped('The Routing component is needed to run tests that depend on its request context.');
     }
@@ -83,8 +83,10 @@ class UrlHelperTest extends TestCase
     $this->assertEquals($path, $helper->getAbsoluteUrl($path));
   }
 
-  public function getGenerateAbsoluteUrlRequestContextData()
-  {
+  /**
+   * GetGenerateAbsoluteUrlRequestContextData.
+   */
+  public function getGenerateAbsoluteUrlRequestContextData() {
     return [
       ['/foo.png', '/foo', 'localhost', 'http', 80, 443, 'http://localhost/foo.png'],
       ['foo.png', '/foo', 'localhost', 'http', 80, 443, 'http://localhost/foo/foo.png'],
@@ -97,8 +99,10 @@ class UrlHelperTest extends TestCase
     ];
   }
 
-  public function testGenerateAbsoluteUrlWithScriptFileName()
-  {
+  /**
+   * TestGenerateAbsoluteUrlWithScriptFileName.
+   */
+  public function testGenerateAbsoluteUrlWithScriptFileName() {
     $request = Request::create('http://localhost/app/web/app_dev.php');
     $request->server->set('SCRIPT_FILENAME', '/var/www/app/web/app_dev.php');
 
@@ -113,10 +117,11 @@ class UrlHelperTest extends TestCase
   }
 
   /**
+   * TestGenerateRelativePath.
+   *
    * @dataProvider getGenerateRelativePathData()
    */
-  public function testGenerateRelativePath($expected, $path, $pathinfo)
-  {
+  public function testGenerateRelativePath($expected, $path, $pathinfo) {
     if (!method_exists('Symfony\Component\HttpFoundation\Request', 'getRelativeUriForPath')) {
       $this->markTestSkipped('Your version of Symfony HttpFoundation is too old.');
     }
@@ -128,8 +133,10 @@ class UrlHelperTest extends TestCase
     $this->assertEquals($expected, $urlHelper->getRelativePath($path));
   }
 
-  public function getGenerateRelativePathData()
-  {
+  /**
+   * GetGenerateRelativePathData.
+   */
+  public function getGenerateRelativePathData() {
     return [
       ['../foo.png', '/foo.png', '/foo/bar.html'],
       ['../baz/foo.png', '/baz/foo.png', '/foo/bar.html'],
@@ -140,4 +147,5 @@ class UrlHelperTest extends TestCase
       ['//example.com/baz', '//example.com/baz', '/'],
     ];
   }
+
 }


### PR DESCRIPTION
### 💬 Describe the pull request
I really miss the twig utility function [`absolute_url`](https://symfony.com/doc/current/reference/twig_reference.html#absolute-url) from Symfony.


#### bamboo_absolute_url
```twig
<img src="{{ bamboo_absolute_url('/images/drupal.png') }}" alt="Drupal" />

{# or in a  theme #}

<img src="{{ {{ bamboo_absolute_url('/' ~ directory ~ '/assets/images/logo.svg') }} }}" alt="Logo" />
```


#### bamboo_relative_path
I also backported `relative_path` helper but I use it less often:

```twig
{{ relative_path('http://example.com/human.txt') }}
{# ../human.txt #}

{{ relative_path('http://example.com/products/products_icon.png') }}
{# products_icon.png #}
```

What do you think ?