### PR TITLE
Issue #3110310 by wengerk, rattusrattus, sahaj, interdruper, gido: Blocks rendered via bamboo_render_block do not use the block theme hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - re-enable PHPUnit Symfony Deprecation notice
 - update codebase to be compliant PHP8.2
 - rework tests by using a custom theme "bamboo_twig" in order of overriding *.html.twig template for tests purpose
+- change Blocks rendered via bamboo_render_block do not use the block theme hook - Issue #3110310 by wengerk, rattusrattus, sahaj, interdruper, gido
 
 ### Added
 - add coverage of Drupal 10.1.x

--- a/README.md
+++ b/README.md
@@ -331,11 +331,12 @@ of the requested image.
 
 **Render**
 
-`bamboo_render_block(block_name, params)` returns a render array of the
+`bamboo_render_block(block_name, params, wrapper)` returns a render array of the
 specified block (works only for Plugin Block).
 
 - `block_name` string
 - `params` array (optional)
+- `wrapper` bool (optional) Whether it use block template for rendering. Defaults: FALSE.
 
 ```twig
 {# Render the `system_powered_by_block` block #}

--- a/bamboo_twig_loader/src/TwigExtension/Render.php
+++ b/bamboo_twig_loader/src/TwigExtension/Render.php
@@ -48,11 +48,13 @@ class Render extends TwigExtensionBase {
    *   The ID of the block to render.
    * @param array $params
    *   (optional) An array of parameters passed to the block.
+   * @param bool $wrapper
+   *   (Optional) Whether it use block template for rendering.
    *
    * @return null|array
    *   A render array for the block or NULL if the block does not exist.
    */
-  public function renderBlock($block_id, array $params = []) {
+  public function renderBlock($block_id, array $params = [], $wrapper = FALSE) {
     /** @var \Drupal\Core\Block\BlockPluginInterface $plugin */
     $plugin = $this->getPluginManagerBlock()->createInstance($block_id, $params);
 
@@ -62,7 +64,20 @@ class Render extends TwigExtensionBase {
       $this->getContextHandler()->applyContextMapping($plugin, $contexts);
     }
 
-    return $plugin->build($params);
+    if (!$wrapper) {
+      return $plugin->build($params);
+    }
+
+    return [
+      '#theme' => 'block',
+      '#attributes' => [],
+      '#contextual_links' => [],
+      '#configuration' => $plugin->getConfiguration(),
+      '#plugin_id' => $plugin->getPluginId(),
+      '#base_plugin_id' => $plugin->getBaseId(),
+      '#derivative_plugin_id' => $plugin->getDerivativeId(),
+      'content' => $plugin->build($params),
+    ];
   }
 
   /**

--- a/tests/src/Kernel/Loader/EntityBlockTest.php
+++ b/tests/src/Kernel/Loader/EntityBlockTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Drupal\Tests\bamboo_twig\Kernel\Loader;
+
+use Drupal\block\Entity\Block;
+use Drupal\block_content\Entity\BlockContent;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\Tests\block\Traits\BlockCreationTrait;
+use Drupal\Tests\bamboo_twig\Traits\BlockCreationTrait as BambooBlockCreationTrait;
+
+/**
+ * @coversDefaultClass \Drupal\bamboo_twig_loader\TwigExtension\Loader
+ *
+ * @group bamboo_twig
+ * @group bamboo_twig_loader
+ */
+class EntityBlockTest extends KernelTestBase {
+  use BlockCreationTrait;
+  use BambooBlockCreationTrait;
+
+  /**
+   * The Bamboo Twig Loader Extension.
+   *
+   * @var \Drupal\bamboo_twig_loader\TwigExtension\Loader
+   */
+  protected $loaderExtension;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'block',
+    'block_content',
+    'block_test',
+    'field',
+    'text',
+    'bamboo_twig',
+    'bamboo_twig_loader',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('block_content');
+    $this->installConfig(['block_content']);
+    $this->installConfig(['block_test']);
+
+    $this->createBlockContentType('basic');
+
+    /** @var \Drupal\bamboo_twig_loader\TwigExtension\Loader $loaderExtension */
+    $this->loaderExtension = $this->container->get('bamboo_twig_loader.twig.loader');
+  }
+
+  /**
+   * @covers ::loadEntity
+   *
+   * Cover the usage of {{ bamboo_render_entity('block', 'stark_branding') }}.
+   */
+  public function testLoaderBlockEntity() {
+    $entity = $this->loaderExtension->loadEntity('block', 'test_block');
+    $this->assertInstanceOf(Block::class, $entity);
+  }
+
+  /**
+   * @covers ::loadEntity
+   *
+   * Cover the usage of {{ bamboo_render_entity('block_content', 1) }}.
+   */
+  public function testLoaderBlockContentEntity() {
+    $block = $this->createBlockContent();
+    $entity = $this->loaderExtension->loadEntity('block_content', $block->id());
+    $this->assertInstanceOf(BlockContent::class, $entity);
+  }
+
+}

--- a/tests/src/Kernel/Loader/EntityBlockTest.php
+++ b/tests/src/Kernel/Loader/EntityBlockTest.php
@@ -60,7 +60,7 @@ class EntityBlockTest extends KernelTestBase {
   /**
    * @covers ::loadEntity
    *
-   * Cover the usage of {{ bamboo_render_entity('block', 'stark_branding') }}.
+   * Cover the usage of {{ bamboo_load_entity('block', 'stark_branding') }}.
    */
   public function testLoaderBlockEntity() {
     $entity = $this->loaderExtension->loadEntity('block', 'test_block');
@@ -70,7 +70,7 @@ class EntityBlockTest extends KernelTestBase {
   /**
    * @covers ::loadEntity
    *
-   * Cover the usage of {{ bamboo_render_entity('block_content', 1) }}.
+   * Cover the usage of {{ bamboo_load_entity('block_content', 1) }}.
    */
   public function testLoaderBlockContentEntity() {
     $block = $this->createBlockContent();

--- a/tests/src/Kernel/Render/ContentBlockTest.php
+++ b/tests/src/Kernel/Render/ContentBlockTest.php
@@ -69,7 +69,7 @@ class ContentBlockTest extends KernelTestBase {
     $this->assertArrayHasKey('#block_content', $renderer);
     $this->assertInstanceOf(BlockContent::class, $renderer['#block_content']);
 
-    // Ensure {{ bamboo_render_block('block_content:ca1f2401-1', [], FALSE) }}.
+    // Ensure {{ bamboo_render_block('block_content:ca1f2401-1', [], TRUE) }}.
     $renderer = $this->renderExtension->renderBlock('block_content:' . $block->uuid(), [], TRUE);
     $this->assertArrayHasKey('#theme', $renderer);
     $this->assertEquals('block', $renderer['#theme']);

--- a/tests/src/Kernel/Render/ContentBlockTest.php
+++ b/tests/src/Kernel/Render/ContentBlockTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Drupal\Tests\bamboo_twig\Kernel\Render;
+
+use Drupal\block_content\Entity\BlockContent;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\Tests\block\Traits\BlockCreationTrait;
+use Drupal\Tests\bamboo_twig\Traits\BlockCreationTrait as BambooBlockCreationTrait;
+
+/**
+ * @coversDefaultClass \Drupal\bamboo_twig_loader\TwigExtension\Render
+ *
+ * @group bamboo_twig
+ * @group bamboo_twig_render
+ */
+class ContentBlockTest extends KernelTestBase {
+  use BlockCreationTrait;
+  use BambooBlockCreationTrait;
+
+  /**
+   * The Bamboo Twig Render Extension.
+   *
+   * @var \Drupal\bamboo_twig_loader\TwigExtension\Render
+   */
+  protected $renderExtension;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'block',
+    'block_content',
+    'field',
+    'text',
+    'bamboo_twig',
+    'bamboo_twig_loader',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('block_content');
+    $this->installConfig(['block_content']);
+
+    $this->createBlockContentType('basic');
+
+    /** @var \Drupal\bamboo_twig_loader\TwigExtension\Render $renderExtension */
+    $this->renderExtension = $this->container->get('bamboo_twig_loader.twig.render');
+  }
+
+  /**
+   * @covers ::renderBlock
+   *
+   * Cover the usage of
+   * {{ bamboo_render_block('block_content:ca1f2401-16a3-474b') }}.
+   * {{ bamboo_render_block('block_content:ca1f2401-16a3-474b', [], FALSE) }}.
+   */
+  public function testRenderContentBlock() {
+    $block = $this->createBlockContent();
+    $this->placeBlock('block_content:' . $block->uuid());
+
+    // Ensure {{ bamboo_render_block('block_content:ca1f2401-1') }}.
+    $renderer = $this->renderExtension->renderBlock('block_content:' . $block->uuid(), [], FALSE);
+    $this->assertArrayHasKey('#block_content', $renderer);
+    $this->assertInstanceOf(BlockContent::class, $renderer['#block_content']);
+
+    // Ensure {{ bamboo_render_block('block_content:ca1f2401-1', [], FALSE) }}.
+    $renderer = $this->renderExtension->renderBlock('block_content:' . $block->uuid(), [], TRUE);
+    $this->assertArrayHasKey('#theme', $renderer);
+    $this->assertEquals('block', $renderer['#theme']);
+  }
+
+}

--- a/tests/src/Kernel/Render/ContentBlockTest.php
+++ b/tests/src/Kernel/Render/ContentBlockTest.php
@@ -58,7 +58,7 @@ class ContentBlockTest extends KernelTestBase {
    *
    * Cover the usage of
    * {{ bamboo_render_block('block_content:ca1f2401-16a3-474b') }}.
-   * {{ bamboo_render_block('block_content:ca1f2401-16a3-474b', [], FALSE) }}.
+   * {{ bamboo_render_block('block_content:ca1f2401-16a3-474b', [], TRUE) }}.
    */
   public function testRenderContentBlock() {
     $block = $this->createBlockContent();

--- a/tests/src/Kernel/Render/PluginBlockTest.php
+++ b/tests/src/Kernel/Render/PluginBlockTest.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Drupal\Tests\bamboo_twig\Kernel\Render;
+
+use Drupal\block\Entity\Block;
+use Drupal\Core\Render\Markup;
+use Drupal\KernelTests\KernelTestBase;
+
+/**
+ * @coversDefaultClass \Drupal\bamboo_twig_loader\TwigExtension\Render
+ *
+ * @group bamboo_twig
+ * @group bamboo_twig_render
+ */
+class PluginBlockTest extends KernelTestBase {
+
+  /**
+   * The renderer service.
+   *
+   * @var \Drupal\Core\Render\RendererInterface
+   */
+  protected $renderer;
+
+  /**
+   * The Bamboo Twig Render Extension.
+   *
+   * @var \Drupal\bamboo_twig_loader\TwigExtension\Render
+   */
+  protected $renderExtension;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'block',
+    'block_test',
+    'bamboo_twig',
+    'bamboo_twig_loader',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    /** @var \Drupal\bamboo_twig_loader\TwigExtension\Render $renderExtension */
+    $this->renderExtension = $this->container->get('bamboo_twig_loader.twig.render');
+
+    $this->renderer = $this->container->get('renderer');
+  }
+
+  /**
+   * @covers ::renderBlock
+   *
+   * Cover the usage of {{ bamboo_render_block('system_powered_by_block') }}.
+   */
+  public function testRenderSystemPluginBlock() {
+    Block::create([
+      'id' => $this->randomMachineName(),
+      'plugin' => 'system_powered_by_block',
+    ]);
+
+    // Ensure {{ bamboo_render_block('system_powered_by_block') }}.
+    $renderer = $this->renderExtension->renderBlock('system_powered_by_block', [], FALSE);
+    $this->assertSame(['#markup'], array_keys($renderer));
+    $markup = $this->renderer->renderRoot($renderer);
+    $this->assertEquals('<span>Powered by <a href="https://www.drupal.org">Drupal</a></span>', $markup->__toString());
+
+    // Ensure {{ bamboo_render_block('test_settings_validation', [], TRUE) }}.
+    $renderer = $this->renderExtension->renderBlock('system_powered_by_block', [], TRUE);
+    $this->assertSame([
+      '#theme',
+      '#attributes',
+      '#contextual_links',
+      '#configuration',
+      '#plugin_id',
+      '#base_plugin_id',
+      '#derivative_plugin_id',
+      'content',
+    ], array_keys($renderer));
+
+    $markup = $this->renderer->renderRoot($renderer);
+    $expected_output = <<<HTML
+<div>
+    <span>Powered by <a href="https://www.drupal.org">Drupal</a></span>
+</div>
+HTML;
+    self::assertXmlStringEqualsXmlString($expected_output, $markup->__toString());
+  }
+
+  /**
+   * @covers ::renderBlock
+   *
+   * Cover the usage of {{ bamboo_render_block('test_settings_validation') }}.
+   */
+  public function testRenderCustomPluginBlock() {
+    // Ensure {{ bamboo_render_block('test_settings_validation', [], FALSE) }}.
+    $renderer = $this->renderExtension->renderBlock('test_settings_validation');
+    $this->assertSame(['#markup'], array_keys($renderer));
+    $markup = $this->renderer->renderRoot($renderer);
+    $this->assertArrayHasKey('#markup', $renderer);
+    $this->assertInstanceOf(Markup::class, $markup);
+    $this->assertEquals('foo', $markup->__toString());
+
+    // Ensure {{ bamboo_render_block('test_settings_validation', [], TRUE) }}.
+    $renderer = $this->renderExtension->renderBlock('test_settings_validation', [], TRUE);
+    $this->assertSame([
+      '#theme',
+      '#attributes',
+      '#contextual_links',
+      '#configuration',
+      '#plugin_id',
+      '#base_plugin_id',
+      '#derivative_plugin_id',
+      'content',
+    ], array_keys($renderer));
+
+    $markup = $this->renderer->renderRoot($renderer);
+    $this->assertInstanceOf(Markup::class, $markup);
+
+    $expected_output = <<<HTML
+<div>
+  
+    
+      foo
+  </div>
+HTML;
+    $this->assertXmlStringEqualsXmlString($expected_output, $markup->__toString());
+  }
+
+}

--- a/tests/src/Traits/BlockCreationTrait.php
+++ b/tests/src/Traits/BlockCreationTrait.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Drupal\Tests\bamboo_twig\Traits;
+
+use Drupal\block_content\Entity\BlockContent;
+use Drupal\block_content\Entity\BlockContentType;
+
+/**
+ * Provides methods to create and place block with default settings.
+ *
+ * This trait is meant to be used only by test classes.
+ */
+trait BlockCreationTrait {
+
+  /**
+   * Create a custom Block Content type.
+   *
+   * @param string $type
+   *   The block type to create or load.
+   * @param string|null $label
+   *   (optional) The label to attach with the created block content type.
+   *
+   * @return \Drupal\block_content\Entity\BlockContentType
+   *   The created block content type.
+   *
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   */
+  protected function createBlockContentType(string $type, ?string $label = NULL): BlockContentType {
+    $block_content_type = BlockContentType::load($type);
+    if (!$block_content_type) {
+      $block_content_type = BlockContentType::create([
+        'id' => $type,
+        'label' => $label ?? $this->randomString(),
+        'revision' => FALSE,
+      ]);
+      $block_content_type->save();
+    }
+
+    return $block_content_type;
+  }
+
+  /**
+   * Creates a custom block.
+   *
+   * @param bool|string $title
+   *   (optional) Title of block. When no value is given uses a random name.
+   *   Defaults to FALSE.
+   * @param string $bundle
+   *   (optional) Bundle name. Defaults to 'basic'.
+   * @param bool $save
+   *   (optional) Whether to save the block. Defaults to TRUE.
+   *
+   * @return \Drupal\block_content\Entity\BlockContent
+   *   Created custom block.
+   *
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   */
+  protected function createBlockContent($title = FALSE, $bundle = 'basic', $save = TRUE): BlockContent {
+    $title = $title ?: $this->randomMachineName();
+    $block_content = BlockContent::create([
+      'info' => $title,
+      'type' => $bundle,
+      'langcode' => 'en',
+    ]);
+    if ($block_content && $save === TRUE) {
+      $block_content->save();
+    }
+    return $block_content;
+  }
+
+}


### PR DESCRIPTION
### 💬 Describe the pull request/code changes
_A clear and concise description of what the pull request is about._
Issue #3110310 by wengerk, rattusrattus, sahaj, interdruper, gido: Blocks rendered via bamboo_render_block do not use the block theme hook

### 🎟️ Drupal.org
_This pull request is related to the following issue(s):_
https://www.drupal.org/project/bamboo_twig/issues/3110310

### 📝 Checklist
- [x] Update the "Unreleased" section of the `CHANGELOG.md` with [chan](https://github.com/geut/chan/tree/main/packages/chan).  _(if applicable)_
- [x] The PR is covered by some tests. _(if applicable)_
