### PR TITLE
Issue #3355084 bamboo_render_image not displaying alt text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - allow Render form mixed parameter types - Issue #3273960 by darrenwh, wengerk
 - add `bamboo_render_entity_revision` rendering of entity revision - Issue #3254160 by dibix, wengerk
 - add `bamboo_load_entity_revision` loading of entity revision - Issue #3254160 by dibix, wengerk
+- add support of optional `alt` parameter on `bamboo_render_image` - Issue #3355084 by Ranjit1032002, thatlotnextdoor, wengerk
 
 ## [6.0.0] - 2022-11-18
 ### Added

--- a/README.md
+++ b/README.md
@@ -432,10 +432,11 @@ entity revision type. Can be rendered a specific `view_mode`.
 
 - `fid` int
 - `style` string
+- `alt` string (optional) - the image alternative text
 
 ```twig
 {# Get thumbnail from image with fid 12. #}
-{{ bamboo_render_image(1, 'thumbnail') }}
+{{ bamboo_render_image(1, 'thumbnail', 'Alternative text.') }}
 ```
 
 `bamboo_render_image_style(path, style, preprocess)` returns the URL string of the

--- a/bamboo_twig_loader/src/TwigExtension/Render.php
+++ b/bamboo_twig_loader/src/TwigExtension/Render.php
@@ -176,7 +176,7 @@ class Render extends TwigExtensionBase {
    *   The image File ID of the entity to render.
    * @param string $style
    *   The image style.
-   * @param string $alt
+   * @param string|null $alt
    *   An optional image alternative text to be used.
    *
    * @return string

--- a/bamboo_twig_loader/src/TwigExtension/Render.php
+++ b/bamboo_twig_loader/src/TwigExtension/Render.php
@@ -176,22 +176,26 @@ class Render extends TwigExtensionBase {
    *   The image File ID of the entity to render.
    * @param string $style
    *   The image style.
+   * @param string $alt
+   *   An optional image alternative text to be used.
    *
    * @return string
    *   A render array for the image style or NULL if the image does not exist.
    */
-  public function renderImage($id, $style) {
+  public function renderImage($id, $style, $alt = NULL) {
     $file = $this->getFileStorage()->load($id);
 
     // Check the entity exist.
-    if ($file) {
-      return [
-        '#theme'      => 'image_style',
-        '#style_name' => $style,
-        '#uri'        => $file->getFileUri(),
-      ];
+    if (!$file) {
+      return NULL;
     }
-    return NULL;
+
+    return [
+      '#theme' => 'image_style',
+      '#style_name' => $style,
+      '#uri' => $file->getFileUri(),
+      '#alt' => $alt,
+    ];
   }
 
   /**

--- a/tests/src/Functional/BambooTwigRenderTest.php
+++ b/tests/src/Functional/BambooTwigRenderTest.php
@@ -319,6 +319,7 @@ class BambooTwigRenderTest extends BambooTwigTestBase {
     $this->drupalGet('/bamboo-twig-render');
     $this->assertSession()->elementExists('css', '.test-render div.render-image');
     $this->assertSession()->elementExists('css', '.test-render div.render-image img');
+    $this->assertSession()->elementExists('css', '.test-render div.render-image-alt img[alt="Quam litora posuere"]');
   }
 
   /**

--- a/tests/src/Kernel/Render/ImageTest.php
+++ b/tests/src/Kernel/Render/ImageTest.php
@@ -1,0 +1,217 @@
+<?php
+
+namespace Drupal\Tests\bamboo_twig\Kernel\Render;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\Tests\media\Traits\MediaTypeCreationTrait;
+use Drupal\Core\StreamWrapper\PublicStream;
+use Drupal\file\FileInterface;
+use Drupal\Core\Render\Markup;
+
+/**
+ * @coversDefaultClass \Drupal\bamboo_twig_loader\TwigExtension\Render
+ *
+ * @group bamboo_twig
+ * @group bamboo_twig_render
+ */
+class ImageTest extends KernelTestBase {
+  use MediaTypeCreationTrait;
+
+  /**
+   * The Bamboo Twig Render Extension.
+   *
+   * @var \Drupal\bamboo_twig_loader\TwigExtension\Render
+   */
+  protected $renderExtension;
+
+  /**
+   * The renderer service.
+   *
+   * @var \Drupal\Core\Render\RendererInterface
+   */
+  protected $renderer;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'media',
+    'image',
+    'user',
+    'field',
+    'system',
+    'file',
+    'bamboo_twig',
+    'bamboo_twig_loader',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('file');
+    $this->installSchema('file', 'file_usage');
+    $this->installSchema('system', 'sequences');
+    $this->installEntitySchema('media');
+    $this->installConfig(['field', 'system', 'image', 'file', 'media']);
+
+    // Create an image media type for testing the renderer.
+    $this->createMediaType('image', ['id' => 'image']);
+
+    /** @var \Drupal\bamboo_twig_loader\TwigExtension\Render $renderExtension */
+    $this->renderExtension = $this->container->get('bamboo_twig_loader.twig.render');
+
+    $this->renderer = $this->container->get('renderer');
+  }
+
+  /**
+   * Creates and gets test image file.
+   *
+   * @return \Drupal\file\FileInterface
+   *   File object.
+   */
+  protected function createFile() {
+    /** @var \Drupal\Component\PhpStorage\FileStorage $file_storage */
+    $file_storage = $this->container->get('entity_type.manager')->getStorage('file');
+    /** @var \Drupal\Core\File\FileSystemInterface $file_system */
+    $file_system = $this->container->get('file_system');
+
+    $file_system->copy(\Drupal::service('extension.list.module')->getPath('bamboo_twig_test') . '/files/antistatique.jpg', PublicStream::basePath());
+
+    $file = $file_storage->create([
+      'uri' => 'public://antistatique.jpg',
+      'status' => FileInterface::STATUS_PERMANENT,
+    ]);
+    $file->save();
+
+    return $file;
+  }
+
+  /**
+   * Creates and gets test image Media.
+   *
+   * @return \Drupal\file\FileInterface
+   *   File object.
+   */
+  protected function createMedia() {
+    $file = $this->createFile();
+
+    /** @var \Drupal\media\MediaStorage $media_storage */
+    $media_storage = $this->container->get('entity_type.manager')->getStorage('media');
+
+    $mediaImage = $media_storage->create([
+      'bundle' => 'image',
+      'name' => 'Test image',
+      'field_media_image' => $file->id(),
+    ]);
+    $mediaImage->save();
+
+    return $mediaImage;
+  }
+
+  /**
+   * @covers ::renderImage
+   *
+   * Cover the usage of
+   * {{ bamboo_render_image(1, 'thumbnail') }}.
+   * {{ bamboo_render_image(1, 'thumbnail', '') }}.
+   * {{ bamboo_render_image(1, 'thumbnail', 'Dignissim (...) primis') }}.
+   */
+  public function testRenderImageFile() {
+    $file = $this->createFile();
+
+    // Ensure {{ bamboo_render_image(1, 'thumbnail') }}.
+    $renderer = $this->renderExtension->renderImage($file->id(), 'thumbnail');
+    $this->assertEquals([
+      '#theme' => 'image_style',
+      '#style_name' => 'thumbnail',
+      '#uri' => 'public://antistatique.jpg',
+      '#alt' => NULL,
+    ], $renderer);
+
+    $markup = $this->renderer->renderRoot($renderer);
+    $this->assertInstanceOf(Markup::class, $markup);
+    $this->assertMatchesRegularExpression('/^<img src=".*public\/antistatique\.jpg\?itok=.*" \/>/', $markup->__toString());
+
+    // Ensure {{ bamboo_render_image(1, 'thumbnail', '') }}.
+    $renderer = $this->renderExtension->renderImage($file->id(), 'thumbnail', '');
+    $this->assertEquals([
+      '#theme' => 'image_style',
+      '#style_name' => 'thumbnail',
+      '#uri' => 'public://antistatique.jpg',
+      '#alt' => '',
+    ], $renderer);
+
+    $markup = $this->renderer->renderRoot($renderer);
+    $this->assertInstanceOf(Markup::class, $markup);
+    $this->assertMatchesRegularExpression('/^<img src=".*public\/antistatique\.jpg\?itok=.*" alt="" \/>/', $markup->__toString());
+
+    // Ensure {{ bamboo_render_image(1, 'thumbnail', 'Dignissim ... primis') }}.
+    $renderer = $this->renderExtension->renderImage($file->id(), 'thumbnail', 'Dignissim dui dolor ipsum sapien habitant primis');
+    $this->assertEquals([
+      '#theme' => 'image_style',
+      '#style_name' => 'thumbnail',
+      '#uri' => 'public://antistatique.jpg',
+      '#alt' => 'Dignissim dui dolor ipsum sapien habitant primis',
+    ], $renderer);
+
+    $markup = $this->renderer->renderRoot($renderer);
+    $this->assertInstanceOf(Markup::class, $markup);
+    $this->assertMatchesRegularExpression('/^<img src=".*public\/antistatique\.jpg\?itok=.*" alt="Dignissim dui dolor ipsum sapien habitant primis" \/>/', $markup->__toString());
+  }
+
+  /**
+   * @covers ::renderImage
+   *
+   * Cover the usage of
+   * {{ bamboo_render_image(1, 'thumbnail') }}.
+   * {{ bamboo_render_image(1, 'thumbnail', '') }}.
+   * {{ bamboo_render_image(1, 'thumbnail', 'Dignissim (...) primis') }}.
+   */
+  public function testRenderImageMedia() {
+    $media = $this->createMedia();
+
+    // Ensure {{ bamboo_render_image(1, 'thumbnail') }}.
+    $renderer = $this->renderExtension->renderImage($media->field_media_image->target_id, 'thumbnail');
+    $this->assertEquals([
+      '#theme' => 'image_style',
+      '#style_name' => 'thumbnail',
+      '#uri' => 'public://antistatique.jpg',
+      '#alt' => NULL,
+    ], $renderer);
+
+    $markup = $this->renderer->renderRoot($renderer);
+    $this->assertInstanceOf(Markup::class, $markup);
+    $this->assertMatchesRegularExpression('/^<img src=".*public\/antistatique\.jpg\?itok=.*" \/>/', $markup->__toString());
+
+    // Ensure {{ bamboo_render_image(1, 'thumbnail', '') }}.
+    $renderer = $this->renderExtension->renderImage($media->field_media_image->target_id, 'thumbnail', '');
+    $this->assertEquals([
+      '#theme' => 'image_style',
+      '#style_name' => 'thumbnail',
+      '#uri' => 'public://antistatique.jpg',
+      '#alt' => '',
+    ], $renderer);
+
+    $markup = $this->renderer->renderRoot($renderer);
+    $this->assertInstanceOf(Markup::class, $markup);
+    $this->assertMatchesRegularExpression('/^<img src=".*public\/antistatique\.jpg\?itok=.*" alt="" \/>/', $markup->__toString());
+
+    // Ensure {{ bamboo_render_image(1, 'thumbnail', 'Dignissim ... primis') }}.
+    $renderer = $this->renderExtension->renderImage($media->field_media_image->target_id, 'thumbnail', 'Dignissim dui dolor ipsum sapien habitant primis');
+    $this->assertEquals([
+      '#theme' => 'image_style',
+      '#style_name' => 'thumbnail',
+      '#uri' => 'public://antistatique.jpg',
+      '#alt' => 'Dignissim dui dolor ipsum sapien habitant primis',
+    ], $renderer);
+
+    $markup = $this->renderer->renderRoot($renderer);
+    $this->assertInstanceOf(Markup::class, $markup);
+    $this->assertMatchesRegularExpression('/^<img src=".*public\/antistatique\.jpg\?itok=.*" alt="Dignissim dui dolor ipsum sapien habitant primis" \/>/', $markup->__toString());
+  }
+
+}

--- a/tests/themes/bamboo_twig_test/templates/bamboo_twig/render.html.twig
+++ b/tests/themes/bamboo_twig_test/templates/bamboo_twig/render.html.twig
@@ -68,6 +68,7 @@
   <h2>Render Image</h2>
   <hr>
   <div class="render-image">{{ bamboo_render_image(1, 'thumbnail') }}</div>
+  <div class="render-image-alt">{{ bamboo_render_image(1, 'thumbnail', 'Quam litora posuere') }}</div>
   <div class="render-image-style-uri">style-uri-{{ bamboo_render_image_style('public://antistatique.jpg', 'thumbnail') }}</div>
   <div class="render-image-style-uri-preprocess">style-uri-preprocess-{{ bamboo_render_image_style('public://antistatique.jpg', 'thumbnail', TRUE) }}</div>
 


### PR DESCRIPTION
### 💬 Description
- add support of optional `alt` parameter on `bamboo_render_image` - Issue #3355084 by Ranjit1032002, thatlotnextdoor, wengerk

### 🎟️ Issue(s)
https://www.drupal.org/project/bamboo_twig/issues/3355084

- [x] Update the "Unreleased" section of the `CHANGELOG.md` with [chan](https://github.com/geut/chan/tree/main/packages/chan)
