### PR TITLE
add official support of drupal 11.x-dev

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,13 @@ jobs:
 
     strategy:
       matrix:
-        drupal_version: ['9.5', '10.0', '10.1']
+        drupal_version: ['9.5', '10.0', '10.1', '10.2', '11.0']
         module: ['bamboo_twig']
         experimental: [false]
+        include:
+          - drupal_version: '11.0'
+            module: 'bamboo_twig'
+            experimental: true
 
     steps:
       - uses: actions/checkout@v3
@@ -37,9 +41,13 @@ jobs:
 
     strategy:
       matrix:
-        drupal_version: ['9.5', '10.0', '10.1']
+        drupal_version: ['9.5', '10.0', '10.1', '10.2', '11.0']
         module: ['bamboo_twig']
         experimental: [false]
+        include:
+          - drupal_version: '11.0'
+            module: 'bamboo_twig'
+            experimental: true
 
     steps:
       - uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - update codebase to be compliant PHP8.2
 - rework tests by using a custom theme "bamboo_twig" in order of overriding *.html.twig template for tests purpose
 - change Blocks rendered via bamboo_render_block do not use the block theme hook - Issue #3110310 by wengerk, rattusrattus, sahaj, interdruper, gido
+- disable PHPUnit Symfony Deprecation notice since Drupal 10.2
 
 ### Added
 - add coverage of Drupal 10.1.x

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - add `bamboo_load_entity_revision` loading of entity revision - Issue #3254160 by dibix, wengerk
 - add support of optional `alt` parameter on `bamboo_render_image` - Issue #3355084 by Ranjit1032002, thatlotnextdoor, wengerk
 - add Drupal GitlabCI - #3417699 #3350583
+- add official support of drupal 11.x-dev
 
 ### Fixed
 - fix tests template discovery using 'path' property

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,9 @@ FROM wengerk/drupal-for-contrib:${BASE_IMAGE_TAG}
 ARG BASE_IMAGE_TAG
 ENV BASE_IMAGE_TAG=${BASE_IMAGE_TAG}
 
-# Disable deprecation notice since PHPUnit 9 with Drupal 9.1 and lower.
-# @see https://www.drupal.org/project/drupal/issues/3259744
-# ENV SYMFONY_DEPRECATIONS_HELPER=weak
+# Disable deprecation notice since PHPUnit 10 with Drupal 10.2 and upper.
+# @see https://www.drupal.org/project/drupal/issues/3403491
+ENV SYMFONY_DEPRECATIONS_HELPER=weak
 
 # Install symfony/mime as required by bamboo_twig_extensions.
 ENV COMPOSER_ALLOW_SUPERUSER=1

--- a/README.md
+++ b/README.md
@@ -46,8 +46,9 @@ for each topic he provides Twigs.
 
 ## Bamboo Twig versions
 
-Bamboo Twig is available for Drupal 8, Drupal 9 & Drupal 10!
+Bamboo Twig is available for Drupal 8, Drupal 9, Drupal 10 & Drupal 11 (dev)!
 
+- If you are running Drupal `11.x`, use Bamboo Twig `6.0.x`.
 - If you are running Drupal `10.x`, use Bamboo Twig `6.0.x`.
 - If you are running Drupal `9.x`, use Bamboo Twig `5.x`.
 - If you are running Drupal `8.8.x`, use Bamboo Twig `5.0`.
@@ -79,6 +80,7 @@ must upgrade to `8.x-3.x` version of **Bamboo Twig**.
 |    8.9.x    |     5.0     |
 |     9.x     |     5.x     |
 |    10.x     |    6.0.x    |
+|  11.x-dev   |    6.0.x    |
 
 ## Dependencies
 

--- a/bamboo_twig.info.yml
+++ b/bamboo_twig.info.yml
@@ -2,4 +2,4 @@ name: Bamboo Twig
 description: 'Several Twig extensions with some useful functions and filters that can improve development experience.'
 package: Bamboo Twig
 type: module
-core_version_requirement: ^9.3 || ^10
+core_version_requirement: ^9.3 || ^10 || ^11

--- a/bamboo_twig_config/bamboo_twig_config.info.yml
+++ b/bamboo_twig_config/bamboo_twig_config.info.yml
@@ -2,7 +2,7 @@ name: Bamboo Twig - Config
 description: 'Several "Config" Twig extensions.'
 package: Bamboo Twig
 type: module
-core_version_requirement: ^9.3 || ^10
+core_version_requirement: ^9.3 || ^10 || ^11
 
 dependencies:
  - bamboo_twig:bamboo_twig

--- a/bamboo_twig_extensions/bamboo_twig_extensions.info.yml
+++ b/bamboo_twig_extensions/bamboo_twig_extensions.info.yml
@@ -2,7 +2,7 @@ name: Bamboo Twig - Extensions
 description: 'Twig extensions (Text, Date & Array) from http://twig-extensions.readthedocs.io/en/latest/index.html.'
 package: Bamboo Twig
 type: module
-core_version_requirement: ^9.3 || ^10
+core_version_requirement: ^9.3 || ^10 || ^11
 
 dependencies:
  - bamboo_twig:bamboo_twig

--- a/bamboo_twig_file/bamboo_twig_file.info.yml
+++ b/bamboo_twig_file/bamboo_twig_file.info.yml
@@ -2,7 +2,7 @@ name: Bamboo Twig - File
 description: 'Several "File" Twig extensions.'
 package: Bamboo Twig
 type: module
-core_version_requirement: ^9.3 || ^10
+core_version_requirement: ^9.3 || ^10 || ^11
 
 dependencies:
  - bamboo_twig:bamboo_twig

--- a/bamboo_twig_i18n/bamboo_twig_i18n.info.yml
+++ b/bamboo_twig_i18n/bamboo_twig_i18n.info.yml
@@ -2,7 +2,7 @@ name: Bamboo Twig - Internationalization
 description: 'Several "i18n" Twig extensions.'
 package: Bamboo Twig
 type: module
-core_version_requirement: ^9.3 || ^10
+core_version_requirement: ^9.3 || ^10 || ^11
 
 dependencies:
  - bamboo_twig:bamboo_twig

--- a/bamboo_twig_loader/bamboo_twig_loader.info.yml
+++ b/bamboo_twig_loader/bamboo_twig_loader.info.yml
@@ -2,7 +2,7 @@ name: Bamboo Twig - Loaders
 description: 'Several "Loaders & Render" Twig extensions.'
 package: Bamboo Twig
 type: module
-core_version_requirement: ^9.3 || ^10
+core_version_requirement: ^9.3 || ^10 || ^11
 
 dependencies:
  - bamboo_twig:bamboo_twig

--- a/bamboo_twig_path/bamboo_twig_path.info.yml
+++ b/bamboo_twig_path/bamboo_twig_path.info.yml
@@ -2,7 +2,7 @@ name: Bamboo Twig - Path & Url
 description: 'Several "Path & Url" Twig extensions.'
 package: Bamboo Twig
 type: module
-core_version_requirement: ^9.3 || ^10
+core_version_requirement: ^9.3 || ^10 || ^11
 
 dependencies:
  - bamboo_twig:bamboo_twig

--- a/bamboo_twig_security/bamboo_twig_security.info.yml
+++ b/bamboo_twig_security/bamboo_twig_security.info.yml
@@ -2,7 +2,7 @@ name: Bamboo Twig - Security
 description: 'Several "Security" Twig extensions.'
 package: Bamboo Twig
 type: module
-core_version_requirement: ^9.3 || ^10
+core_version_requirement: ^9.3 || ^10 || ^11
 
 dependencies:
  - bamboo_twig:bamboo_twig

--- a/bamboo_twig_token/bamboo_twig_token.info.yml
+++ b/bamboo_twig_token/bamboo_twig_token.info.yml
@@ -2,7 +2,7 @@ name: Bamboo Twig - Token
 description: 'Several "Token" Twig extensions.'
 package: Bamboo Twig
 type: module
-core_version_requirement: ^9.3 || ^10
+core_version_requirement: ^9.3 || ^10 || ^11
 
 dependencies:
  - bamboo_twig:bamboo_twig

--- a/tests/modules/bamboo_twig_test/bamboo_twig_test.info.yml
+++ b/tests/modules/bamboo_twig_test/bamboo_twig_test.info.yml
@@ -2,7 +2,7 @@ name: Bamboo Twig test
 description: Support module for Bamboo Twig testing.
 package: Testing
 type: module
-core_version_requirement: ^9.3 || ^10
+core_version_requirement: ^9.3 || ^10 || ^11
 
 dependencies:
   - drupal:bamboo_twig

--- a/tests/src/Kernel/BambooTwigSecurityTest.php
+++ b/tests/src/Kernel/BambooTwigSecurityTest.php
@@ -45,7 +45,12 @@ class BambooTwigSecurityTest extends KernelTestBase {
     parent::setUp();
 
     $this->installEntitySchema('user');
-    $this->installSchema('system', ['sequences']);
+
+    // Since Drupal 10.2.0 installing the table sequences with the
+    // method KernelTestBase::installSchema() is deprecated.
+    if (version_compare(\Drupal::VERSION, '10.2.0', '<')) {
+      $this->installSchema('system', ['sequences']);
+    }
 
     $this->entityTypeManager = $this->container->get('entity_type.manager');
     $this->securityExtension = $this->container->get('bamboo_twig_security.twig.security');

--- a/tests/src/Kernel/Render/ImageTest.php
+++ b/tests/src/Kernel/Render/ImageTest.php
@@ -54,7 +54,13 @@ class ImageTest extends KernelTestBase {
     $this->installEntitySchema('user');
     $this->installEntitySchema('file');
     $this->installSchema('file', 'file_usage');
-    $this->installSchema('system', 'sequences');
+
+    // Since Drupal 10.2.0 installing the table sequences with the
+    // method KernelTestBase::installSchema() is deprecated.
+    if (version_compare(\Drupal::VERSION, '10.2.0', '<')) {
+      $this->installSchema('system', ['sequences']);
+    }
+
     $this->installEntitySchema('media');
     $this->installConfig(['field', 'system', 'image', 'file', 'media']);
 
@@ -134,7 +140,14 @@ class ImageTest extends KernelTestBase {
 
     $markup = $this->renderer->renderRoot($renderer);
     $this->assertInstanceOf(Markup::class, $markup);
-    $this->assertMatchesRegularExpression('/^<img src=".*public\/antistatique\.jpg\?itok=.*" \/>/', $markup->__toString());
+
+    // Since Drupal 11.x the image styles are rendered as webp.
+    if (version_compare(\Drupal::VERSION, '11', '>=')) {
+      $this->assertMatchesRegularExpression('/^<img src=".*public\/antistatique\.jpg.webp\?itok=.*" \/>/', $markup->__toString());
+    }
+    else {
+      $this->assertMatchesRegularExpression('/^<img src=".*public\/antistatique\.jpg\?itok=.*" \/>/', $markup->__toString());
+    }
 
     // Ensure {{ bamboo_render_image(1, 'thumbnail', '') }}.
     $renderer = $this->renderExtension->renderImage($file->id(), 'thumbnail', '');
@@ -147,7 +160,14 @@ class ImageTest extends KernelTestBase {
 
     $markup = $this->renderer->renderRoot($renderer);
     $this->assertInstanceOf(Markup::class, $markup);
-    $this->assertMatchesRegularExpression('/^<img src=".*public\/antistatique\.jpg\?itok=.*" alt="" \/>/', $markup->__toString());
+
+    // Since Drupal 11.x the image styles are rendered as webp.
+    if (version_compare(\Drupal::VERSION, '11', '>=')) {
+      $this->assertMatchesRegularExpression('/^<img src=".*public\/antistatique\.jpg.webp\?itok=.*" alt="" \/>/', $markup->__toString());
+    }
+    else {
+      $this->assertMatchesRegularExpression('/^<img src=".*public\/antistatique\.jpg\?itok=.*" alt="" \/>/', $markup->__toString());
+    }
 
     // Ensure {{ bamboo_render_image(1, 'thumbnail', 'Dignissim ... primis') }}.
     $renderer = $this->renderExtension->renderImage($file->id(), 'thumbnail', 'Dignissim dui dolor ipsum sapien habitant primis');
@@ -160,7 +180,14 @@ class ImageTest extends KernelTestBase {
 
     $markup = $this->renderer->renderRoot($renderer);
     $this->assertInstanceOf(Markup::class, $markup);
-    $this->assertMatchesRegularExpression('/^<img src=".*public\/antistatique\.jpg\?itok=.*" alt="Dignissim dui dolor ipsum sapien habitant primis" \/>/', $markup->__toString());
+
+    // Since Drupal 11.x the image styles are rendered as webp.
+    if (version_compare(\Drupal::VERSION, '11', '>=')) {
+      $this->assertMatchesRegularExpression('/^<img src=".*public\/antistatique\.jpg.webp\?itok=.*" alt="Dignissim dui dolor ipsum sapien habitant primis" \/>/', $markup->__toString());
+    }
+    else {
+      $this->assertMatchesRegularExpression('/^<img src=".*public\/antistatique\.jpg\?itok=.*" alt="Dignissim dui dolor ipsum sapien habitant primis" \/>/', $markup->__toString());
+    }
   }
 
   /**
@@ -185,7 +212,14 @@ class ImageTest extends KernelTestBase {
 
     $markup = $this->renderer->renderRoot($renderer);
     $this->assertInstanceOf(Markup::class, $markup);
-    $this->assertMatchesRegularExpression('/^<img src=".*public\/antistatique\.jpg\?itok=.*" \/>/', $markup->__toString());
+
+    // Since Drupal 11.x the image styles are rendered as webp.
+    if (version_compare(\Drupal::VERSION, '11', '>=')) {
+      $this->assertMatchesRegularExpression('/^<img src=".*public\/antistatique\.jpg.webp\?itok=.*" \/>/', $markup->__toString());
+    }
+    else {
+      $this->assertMatchesRegularExpression('/^<img src=".*public\/antistatique\.jpg\?itok=.*" \/>/', $markup->__toString());
+    }
 
     // Ensure {{ bamboo_render_image(1, 'thumbnail', '') }}.
     $renderer = $this->renderExtension->renderImage($media->field_media_image->target_id, 'thumbnail', '');
@@ -198,7 +232,14 @@ class ImageTest extends KernelTestBase {
 
     $markup = $this->renderer->renderRoot($renderer);
     $this->assertInstanceOf(Markup::class, $markup);
-    $this->assertMatchesRegularExpression('/^<img src=".*public\/antistatique\.jpg\?itok=.*" alt="" \/>/', $markup->__toString());
+
+    // Since Drupal 11.x the image styles are rendered as webp.
+    if (version_compare(\Drupal::VERSION, '11', '>=')) {
+      $this->assertMatchesRegularExpression('/^<img src=".*public\/antistatique\.jpg.webp\?itok=.*" \/>/', $markup->__toString());
+    }
+    else {
+      $this->assertMatchesRegularExpression('/^<img src=".*public\/antistatique\.jpg\?itok=.*" alt="" \/>/', $markup->__toString());
+    }
 
     // Ensure {{ bamboo_render_image(1, 'thumbnail', 'Dignissim ... primis') }}.
     $renderer = $this->renderExtension->renderImage($media->field_media_image->target_id, 'thumbnail', 'Dignissim dui dolor ipsum sapien habitant primis');
@@ -211,7 +252,14 @@ class ImageTest extends KernelTestBase {
 
     $markup = $this->renderer->renderRoot($renderer);
     $this->assertInstanceOf(Markup::class, $markup);
-    $this->assertMatchesRegularExpression('/^<img src=".*public\/antistatique\.jpg\?itok=.*" alt="Dignissim dui dolor ipsum sapien habitant primis" \/>/', $markup->__toString());
+
+    // Since Drupal 11.x the image styles are rendered as webp.
+    if (version_compare(\Drupal::VERSION, '11', '>=')) {
+      $this->assertMatchesRegularExpression('/^<img src=".*public\/antistatique\.jpg.webp\?itok=.*" alt="Dignissim dui dolor ipsum sapien habitant primis" \/>/', $markup->__toString());
+    }
+    else {
+      $this->assertMatchesRegularExpression('/^<img src=".*public\/antistatique\.jpg\?itok=.*" alt="Dignissim dui dolor ipsum sapien habitant primis" \/>/', $markup->__toString());
+    }
   }
 
 }


### PR DESCRIPTION
### 💬 Description
add official support of drupal 11.x-dev


- [ ] Update the "Unreleased" section of the `CHANGELOG.md` with [chan](https://github.com/geut/chan/tree/main/packages/chan)
