### PR TITLE
replace usage of deprecated EntityReferenceTestTrait by EntityReferenceFieldCreationTrait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - update codebase to be compliant PHP8.2
 - rework tests by using a custom theme "bamboo_twig" in order of overriding *.html.twig template for tests purpose
 - change Blocks rendered via bamboo_render_block do not use the block theme hook - Issue #3110310 by wengerk, rattusrattus, sahaj, interdruper, gido
+- replace usage of deprecated EntityReferenceTestTrait by EntityReferenceFieldCreationTrait
 
 ### Added
 - add coverage of Drupal 10.1.x

--- a/tests/src/Functional/BambooTwigTestBase.php
+++ b/tests/src/Functional/BambooTwigTestBase.php
@@ -5,13 +5,11 @@ namespace Drupal\Tests\bamboo_twig\Functional;
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
 use Drupal\language\Entity\ConfigurableLanguage;
 use Drupal\Tests\BrowserTestBase;
-use Drupal\Tests\field\Traits\EntityReferenceTestTrait;
 
 /**
  * Has some additional helper methods to make test code more readable.
  */
 abstract class BambooTwigTestBase extends BrowserTestBase {
-  use EntityReferenceTestTrait;
 
   /**
    * The Entity Type Manager.


### PR DESCRIPTION
### 💬 Description
replace usage of deprecated EntityReferenceTestTrait by EntityReferenceFieldCreationTrait

- [x] Update the "Unreleased" section of the `CHANGELOG.md` with [chan](https://github.com/geut/chan/tree/main/packages/chan)
