### PR TITLE
drop support of Drupal 9.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        drupal_version: ['9.5', '10.0', '10.1', '10.2', '10.3', '10.4', '11.0', '11.1']
+        drupal_version: ['10.0', '10.1', '10.2', '10.3', '10.4', '11.0', '11.1']
         module: ['bamboo_twig']
         experimental: [false]
         include:
@@ -41,7 +41,7 @@ jobs:
 
     strategy:
       matrix:
-        drupal_version: ['9.5', '10.0', '10.1', '10.2', '10.3', '10.4', '11.0', '11.1']
+        drupal_version: ['10.0', '10.1', '10.2', '10.3', '10.4', '11.0', '11.1']
         module: ['bamboo_twig']
         experimental: [false]
         include:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,14 +32,12 @@ variables:
   SKIP_ESLINT: '1'
   # Opt in to testing current minor against max supported PHP version.
   OPT_IN_TEST_MAX_PHP: '1'
-  # Opt in to testing previous & next minor (Drupal 10.2.x and 10.4.x).
+  # Opt in to testing previous minor (Drupal 11.0.13) & next minor (Drupal 11.2-dev).
   OPT_IN_TEST_PREVIOUS_MINOR: '1'
   OPT_IN_TEST_NEXT_MINOR: '1'
-  # Opt in to testing $CORE_PREVIOUS_MAJOR (currently Drupal 9.5).
+  # Opt in to testing $CORE_PREVIOUS_MAJOR (currently Drupal 10.4.6).
   OPT_IN_TEST_PREVIOUS_MAJOR: '1'
-  # The 4.x branch of the CDN module requires PHP >=8.1, rather than core's >=7.4.
-  CORE_PREVIOUS_PHP_MIN: '8.1'
-  # Opt in to testing $CORE_MAJOR_DEVELOPMENT (currently Drupal 11).
+  # Opt in to testing $CORE_MAJOR_DEVELOPMENT (currently Drupal 12).
   OPT_IN_TEST_NEXT_MAJOR: '1'
 
 # This module wants to strictly comply with Drupal's coding standards.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Removed
+- drop support of Drupal 9.x
 
 ## [6.0.3] - 2025-04-23
 ### Added

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ for each topic he provides Twigs.
 
 ## Bamboo Twig versions
 
-Bamboo Twig is available for Drupal 8, Drupal 9, Drupal 10 & Drupal 11 (dev)!
+Bamboo Twig is available for Drupal 8, Drupal 9, Drupal 10 & Drupal 11 !
 
 - If you are running Drupal `11.x`, use Bamboo Twig `6.0.x`.
 - If you are running Drupal `10.x`, use Bamboo Twig `6.0.x`.
@@ -81,7 +81,7 @@ must upgrade to `8.x-3.x` version of **Bamboo Twig**.
 |    8.9.x    |     5.0     |
 |     9.x     |     5.x     |
 |    10.x     |    6.0.x    |
-|  11.x-dev   |    6.0.x    |
+|    11.x     |    6.0.x    |
 
 ## Dependencies
 

--- a/bamboo_twig.info.yml
+++ b/bamboo_twig.info.yml
@@ -2,4 +2,4 @@ name: Bamboo Twig
 description: 'Several Twig extensions with some useful functions and filters that can improve development experience.'
 package: Bamboo Twig
 type: module
-core_version_requirement: ^9.5 || ^10 || ^11
+core_version_requirement: ^10 || ^11

--- a/bamboo_twig_cacheable/bamboo_twig_cacheable.info.yml
+++ b/bamboo_twig_cacheable/bamboo_twig_cacheable.info.yml
@@ -2,7 +2,7 @@ name: Bamboo Twig - Cacheable
 description: 'Several "Cacheable" Twig extensions.'
 package: Bamboo Twig
 type: module
-core_version_requirement: ^9.5 || ^10 || ^11
+core_version_requirement: ^10 || ^11
 
 dependencies:
  - bamboo_twig:bamboo_twig

--- a/bamboo_twig_config/bamboo_twig_config.info.yml
+++ b/bamboo_twig_config/bamboo_twig_config.info.yml
@@ -2,7 +2,7 @@ name: Bamboo Twig - Config
 description: 'Several "Config" Twig extensions.'
 package: Bamboo Twig
 type: module
-core_version_requirement: ^9.5 || ^10 || ^11
+core_version_requirement: ^10 || ^11
 
 dependencies:
  - bamboo_twig:bamboo_twig

--- a/bamboo_twig_extensions/bamboo_twig_extensions.info.yml
+++ b/bamboo_twig_extensions/bamboo_twig_extensions.info.yml
@@ -2,7 +2,7 @@ name: Bamboo Twig - Extensions
 description: 'Twig extensions (Text, Date & Array) from http://twig-extensions.readthedocs.io/en/latest/index.html.'
 package: Bamboo Twig
 type: module
-core_version_requirement: ^9.5 || ^10 || ^11
+core_version_requirement: ^10 || ^11
 
 dependencies:
  - bamboo_twig:bamboo_twig

--- a/bamboo_twig_file/bamboo_twig_file.info.yml
+++ b/bamboo_twig_file/bamboo_twig_file.info.yml
@@ -2,7 +2,7 @@ name: Bamboo Twig - File
 description: 'Several "File" Twig extensions.'
 package: Bamboo Twig
 type: module
-core_version_requirement: ^9.5 || ^10 || ^11
+core_version_requirement: ^10 || ^11
 
 dependencies:
  - bamboo_twig:bamboo_twig

--- a/bamboo_twig_i18n/bamboo_twig_i18n.info.yml
+++ b/bamboo_twig_i18n/bamboo_twig_i18n.info.yml
@@ -2,7 +2,7 @@ name: Bamboo Twig - Internationalization
 description: 'Several "i18n" Twig extensions.'
 package: Bamboo Twig
 type: module
-core_version_requirement: ^9.5 || ^10 || ^11
+core_version_requirement: ^10 || ^11
 
 dependencies:
  - bamboo_twig:bamboo_twig

--- a/bamboo_twig_loader/bamboo_twig_loader.info.yml
+++ b/bamboo_twig_loader/bamboo_twig_loader.info.yml
@@ -2,7 +2,7 @@ name: Bamboo Twig - Loaders
 description: 'Several "Loaders & Render" Twig extensions.'
 package: Bamboo Twig
 type: module
-core_version_requirement: ^9.5 || ^10 || ^11
+core_version_requirement: ^10 || ^11
 
 dependencies:
  - bamboo_twig:bamboo_twig

--- a/bamboo_twig_path/bamboo_twig_path.info.yml
+++ b/bamboo_twig_path/bamboo_twig_path.info.yml
@@ -2,7 +2,7 @@ name: Bamboo Twig - Path & Url
 description: 'Several "Path & Url" Twig extensions.'
 package: Bamboo Twig
 type: module
-core_version_requirement: ^9.5 || ^10 || ^11
+core_version_requirement: ^10 || ^11
 
 dependencies:
  - bamboo_twig:bamboo_twig

--- a/bamboo_twig_security/bamboo_twig_security.info.yml
+++ b/bamboo_twig_security/bamboo_twig_security.info.yml
@@ -2,7 +2,7 @@ name: Bamboo Twig - Security
 description: 'Several "Security" Twig extensions.'
 package: Bamboo Twig
 type: module
-core_version_requirement: ^9.5 || ^10 || ^11
+core_version_requirement: ^10 || ^11
 
 dependencies:
  - bamboo_twig:bamboo_twig

--- a/bamboo_twig_token/bamboo_twig_token.info.yml
+++ b/bamboo_twig_token/bamboo_twig_token.info.yml
@@ -2,7 +2,7 @@ name: Bamboo Twig - Token
 description: 'Several "Token" Twig extensions.'
 package: Bamboo Twig
 type: module
-core_version_requirement: ^9.5 || ^10 || ^11
+core_version_requirement: ^10 || ^11
 
 dependencies:
  - bamboo_twig:bamboo_twig

--- a/tests/modules/bamboo_twig_test/bamboo_twig_test.info.yml
+++ b/tests/modules/bamboo_twig_test/bamboo_twig_test.info.yml
@@ -2,7 +2,7 @@ name: Bamboo Twig test
 description: Support module for Bamboo Twig testing.
 package: Testing
 type: module
-core_version_requirement: ^9.5 || ^10 || ^11
+core_version_requirement: ^10 || ^11
 
 dependencies:
   - drupal:bamboo_twig


### PR DESCRIPTION
### 💬 Description
drop support of Drupal 9.x

- [x] Update the "Unreleased" section of the `CHANGELOG.md` with [chan](https://github.com/geut/chan/tree/main/packages/chan)
