### PR TITLE
ignore phpstan Call to internal function twig_date_converter - already adressed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - fix tests running on 11.2-dev with rendered avif image
 
+### Changed
+- ignore phpstan Call to internal function twig_date_converter - already adressed
+
 ## [6.0.4] - 2025-05-15
 ### Removed
 - drop support of Drupal 9.x

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -9,6 +9,8 @@ parameters:
     - "#^Unsafe usage of new static#"
     # The module support Drupal 10 and Drupal 11, so we cannot fix that deprecation without dropping support of Twig 3.9.3 and below.
     - "#^Call to deprecated function twig_date_converter#"
+    # The module support Drupal 10 and Drupal 11, so we cannot fix that deprecation without dropping support of Twig 3.9.3 and below.
+    - "#^Call to internal function twig_date_converter#"
     # The module support Drupal 10 and Drupal 11, so we cannot fix that deprecation without dropping support of 10.1.x and below.
     -
       message: """


### PR DESCRIPTION
### 💬 Description
ignore phpstan Call to internal function twig_date_converter - already adressed

- [x] Update the "Unreleased" section of the `CHANGELOG.md` with [chan](https://github.com/geut/chan/tree/main/packages/chan)
