### PR TITLE
add official support of drupal 10.6 & 11.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,16 +12,16 @@ jobs:
 
     strategy:
       matrix:
-        drupal_version: ['10.5', '11.0', '11.1', '11.2']
+        drupal_version: ['10.5', '10.6', '11.0', '11.1', '11.2', '11.3']
         module: ['bamboo_twig']
         experimental: [false]
-        include:
-          - drupal_version: '10.6'
-            module: 'bamboo_twig'
-            experimental: true
-          - drupal_version: '11.3'
-            module: 'bamboo_twig'
-            experimental: true
+#         include:
+#           - drupal_version: '10.7'
+#             module: 'bamboo_twig'
+#             experimental: true
+#           - drupal_version: '11.4'
+#             module: 'bamboo_twig'
+#             experimental: true
 
     steps:
       - uses: actions/checkout@v5
@@ -44,16 +44,16 @@ jobs:
 
     strategy:
       matrix:
-        drupal_version: ['10.5', '11.0', '11.1', '11.2']
+        drupal_version: ['10.5', '10.6', '11.0', '11.1', '11.2', '11.3']
         module: ['bamboo_twig']
         experimental: [false]
-        include:
-          - drupal_version: '10.6'
-            module: 'bamboo_twig'
-            experimental: true
-          - drupal_version: '11.3'
-            module: 'bamboo_twig'
-            experimental: true
+#         include:
+#           - drupal_version: '10.7'
+#             module: 'bamboo_twig'
+#             experimental: true
+#           - drupal_version: '11.4'
+#             module: 'bamboo_twig'
+#             experimental: true
 
     steps:
       - uses: actions/checkout@v5
@@ -80,7 +80,7 @@ jobs:
 
     strategy:
       matrix:
-        drupal_version: ['10.5']
+        drupal_version: ['10.6']
         module: ['bamboo_twig']
 
     steps:

--- a/.github/workflows/styles.yml
+++ b/.github/workflows/styles.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: '8.4'
           extensions: mbstring, intl, gd, xml, dom, json, fileinfo, curl, zip, iconv
           tools: cs2pr, composer:v2
       - uses: actions/checkout@v5
@@ -23,7 +23,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: '8.4'
           extensions: mbstring, intl, gd, xml, dom, json, fileinfo, curl, zip, iconv
           tools: cs2pr, composer:v2, phpmd
       - uses: actions/checkout@v5
@@ -37,7 +37,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: '8.4'
           extensions: mbstring, intl, gd, xml, dom, json, fileinfo, curl, zip, iconv
           tools: cs2pr, composer:v2, phpcpd
       - uses: actions/checkout@v5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- add official support of drupal 10.6
+- add official support of drupal 11.3
 
 ## [6.0.5] - 2025-08-25
 ### Fixed

--- a/tests/src/Functional/BambooTwigRenderTest.php
+++ b/tests/src/Functional/BambooTwigRenderTest.php
@@ -455,11 +455,23 @@ class BambooTwigRenderTest extends BambooTwigTestBase {
     $this->drupalGet('/bamboo-twig-render');
     $this->assertSession()->elementExists('css', '.test-render div.render-menu-all');
     $this->assertElementCount('ul', 9, '.test-render div.render-menu-all');
-    $this->assertElementCount('li', 24, '.test-render div.render-menu-all');
+    // Since Drupal 11.3.x the default Drupal distribution have X menu items.
+    if (version_compare(\Drupal::VERSION, '11.2.99', '>')) {
+      $this->assertElementCount('li', 23, '.test-render div.render-menu-all');
+    }
+    else {
+      $this->assertElementCount('li', 24, '.test-render div.render-menu-all');
+    }
 
     $this->assertSession()->elementExists('css', '.test-render div.render-menu-level');
     $this->assertElementCount('ul', 8, '.test-render div.render-menu-level');
-    $this->assertElementCount('li', 23, '.test-render div.render-menu-level');
+    // Since Drupal 11.3.x the default Drupal distribution have X menu items.
+    if (version_compare(\Drupal::VERSION, '11.2.99', '>')) {
+      $this->assertElementCount('li', 22, '.test-render div.render-menu-level');
+    }
+    else {
+      $this->assertElementCount('li', 23, '.test-render div.render-menu-level');
+    }
 
     $this->assertSession()->elementExists('css', '.test-render div.render-menu-depth');
     $this->assertElementCount('ul', 2, '.test-render div.render-menu-depth');

--- a/tests/src/Unit/Cacheable/BubbleMetadataTest.php
+++ b/tests/src/Unit/Cacheable/BubbleMetadataTest.php
@@ -2,8 +2,8 @@
 
 namespace Drupal\Tests\bamboo_twig\Unit\Cacheable;
 
-use Drupal\Tests\UnitTestCase;
 use Drupal\bamboo_twig_cacheable\TwigExtension\BubbleMetadata;
+use Drupal\Tests\UnitTestCase;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**


### PR DESCRIPTION
### 💬 Description

### 🎟️ Issue(s)

### 🔢 To Review
1. 
2. 

- [ ] Update the "Unreleased" section of the `CHANGELOG.md` with [chan](https://github.com/geut/chan/tree/main/packages/chan)
