### PR TITLE
add experimental coverage of Drupal 11.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,13 +15,13 @@ jobs:
         drupal_version: ['10.5', '10.6', '11.0', '11.1', '11.2', '11.3']
         module: ['bamboo_twig']
         experimental: [false]
-#         include:
+        include:
 #           - drupal_version: '10.7'
 #             module: 'bamboo_twig'
 #             experimental: true
-#           - drupal_version: '11.4'
-#             module: 'bamboo_twig'
-#             experimental: true
+          - drupal_version: '11.4'
+            module: 'bamboo_twig'
+            experimental: true
 
     steps:
       - uses: actions/checkout@v6
@@ -47,13 +47,13 @@ jobs:
         drupal_version: ['10.5', '10.6', '11.0', '11.1', '11.2', '11.3']
         module: ['bamboo_twig']
         experimental: [false]
-#         include:
+        include:
 #           - drupal_version: '10.7'
 #             module: 'bamboo_twig'
 #             experimental: true
-#           - drupal_version: '11.4'
-#             module: 'bamboo_twig'
-#             experimental: true
+          - drupal_version: '11.4'
+            module: 'bamboo_twig'
+            experimental: true
 
     steps:
       - uses: actions/checkout@v6

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,15 +30,15 @@ include:
 ################
 variables:
   SKIP_ESLINT: '1'
-  # Opt in to testing current minor against max supported PHP version.
+  # Opt in to testing current minor against max supported PHP version (8.4).
   OPT_IN_TEST_MAX_PHP: '1'
   # Opt in to testing previous minor (Drupal 11.1.x)
   OPT_IN_TEST_PREVIOUS_MINOR: '1'
-  # Opt in to testing next minor (Drupal 11.3.x).
+  # Opt in to testing next minor (Drupal 11.x-dev // 11.4-dev)
   OPT_IN_TEST_NEXT_MINOR: '1'
-  # Opt in to testing $CORE_PREVIOUS_MAJOR (Drupal 10.4.x).
+  # Opt in to testing $CORE_PREVIOUS_MAJOR (Drupal 10.6.x).
   OPT_IN_TEST_PREVIOUS_MAJOR: '1'
-  # Opt in to testing $CORE_MAJOR_DEVELOPMENT (Drupal 12).
+  # Opt in to testing $CORE_MAJOR_DEVELOPMENT (Drupal 12.0-dev).
   OPT_IN_TEST_NEXT_MAJOR: '1'
 
 # This module wants to strictly comply with Drupal's coding standards.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- add experimental coverage of Drupal 11.4
 
 ## [6.0.6] - 2026-01-26
 ### Added


### PR DESCRIPTION
### 💬 Description
add experimental coverage of Drupal 11.4

- [x] Update the "Unreleased" section of the `CHANGELOG.md` with [chan](https://github.com/geut/chan/tree/main/packages/chan)
