### PR TITLE
Docs: Update PHP_CodeSniffer repository link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,7 +70,7 @@ The following Analyzer will be downloaded & installed as PHAR:
 
 #### Running Code Sniffer Drupal & DrupalPractice
 
-https://github.com/squizlabs/PHP_CodeSniffer
+https://github.com/PHPCSStandards/PHP_CodeSniffer
 
 PHP_CodeSniffer is a set of two PHP scripts; the main `phpcs` script that tokenizes PHP, JavaScript and CSS files to
 detect violations of a defined coding standard, and a second `phpcbf` script to automatically correct coding standard


### PR DESCRIPTION
PHP_CodeSniffer has moved to a new GitHub organization. The `squizlabs/PHP_CodeSniffer` repository is now archived and the project is actively maintained at https://github.com/PHPCSStandards/PHP_CodeSniffer.

See: https://github.com/squizlabs/PHP_CodeSniffer/issues/3932