### PR TITLE
fix: add codesniffer to cspell ignore wordlist

### DIFF
--- a/.cspell-project-words.txt
+++ b/.cspell-project-words.txt
@@ -48,3 +48,4 @@ officedocument
 openxmlformats
 wordprocessingml
 datetimeplus
+codesniffer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- fix: add 'codesniffer' to cspell ignore wordlist
 
 ## [6.0.8] - 2026-07-02
 ### Added


### PR DESCRIPTION
### 💬 Description
fix: add codesniffer to cspell ignore wordlist

- [x] Update the "Unreleased" section of the `CHANGELOG.md` with [chan](https://github.com/geut/chan/tree/main/packages/chan)

